### PR TITLE
Release new version 2.4.1.110.0

### DIFF
--- a/deploy/csi-controller-deployment.yaml
+++ b/deploy/csi-controller-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: cfs-driver
-          image: chubaofs/cfs-csi-driver:2.4.0.110.5
+          image: ghcr.io/cubefs/cfs-csi-driver:2.4.1.110.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/deploy/csi-node-daemonset.yaml
+++ b/deploy/csi-node-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
             - mountPath: /registration
               name: registration-dir
         - name: cfs-driver
-          image: chubaofs/cfs-csi-driver:2.4.0.110.5
+          image: ghcr.io/cubefs/cfs-csi-driver:2.4.1.110.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
Signed-off-by: Huweicai <i@huweicai.com>

It's time to release a new version, what's new:
- cfs-client upgraded to 2.4.1
- support crashed remount recover logic
- support kubelet volume metrics
- use go mod instead of vendor
- support set multi master addresses
- optimized cfs-client parameters passthrough logic