### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ so you should add a label for nodes. If you want using CubeFS CSI in whole kuber
 kubectl label node <nodename> component.cubefs.io/csi=enabled
 ```
 
-## 
+##
 
 ## Direct Raw Files Deployment
 
@@ -113,10 +113,10 @@ component:
 image:
   # CSI related images
   csi_driver: ghcr.io/cubefs/cfs-csi-driver:3.2.0.150.0
-  csi_provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-  csi_attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
-  csi_resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-  driver_registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+  csi_provisioner: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+  csi_attacher: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+  csi_resizer: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+  driver_registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
 
 csi:
   driverName: csi.cubefs.com

--- a/deploy/csi-controller-deployment.yaml
+++ b/deploy/csi-controller-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         "component.cubefs.io/csi": "enabled"
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -41,7 +41,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -60,7 +60,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/deploy/csi-node-daemonset.yaml
+++ b/deploy/csi-node-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
         "component.cubefs.io/csi": "enabled"
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.